### PR TITLE
meson-template: add '-Dstrip=true'

### DIFF
--- a/meson-template.SlackBuild
+++ b/meson-template.SlackBuild
@@ -110,6 +110,7 @@ cd build
   CXXFLAGS="$SLKCFLAGS" \
   meson .. \
     --buildtype=release \
+    -Dstrip=true  \
     --infodir=/usr/info \
     --libdir=/usr/lib${LIBDIRSUFFIX} \
     --localstatedir=/var \


### PR DESCRIPTION
This is the Slackbuild that's currently at https://slackbuilds.org/templates, but with one modification: on L113 I've added the `-Dstrip=true` option (strip targets on install).